### PR TITLE
Transform function not work well with umbrella project

### DIFF
--- a/apps/app_one/config/app_one.schema.exs
+++ b/apps/app_one/config/app_one.schema.exs
@@ -60,6 +60,8 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       to: "app_one.port"
     ]
   ],
-  transforms: [],
+  transforms: [
+    "app_one.foo": fn _conf -> "bar" end
+  ],
   validators: []
 ]


### PR DESCRIPTION
`mix conform.effective` is fine.
Error occurs when merging schema files.
I will send a `Conform` issues later.
```
==> conform: loading schema
==> conform: merging config app_one
==> conform: merging config app_two
==> conform: merging config master_app
==> conform: merging schema app_one
==> conform: merging schema app_two
==> conform: merging schema master_app
==> Plugin failed: Invalid schema at line 80: syntax error before: ']'.
```